### PR TITLE
Hide J from stdlib

### DIFF
--- a/src/Relation/Ternary/Morphisms.agda
+++ b/src/Relation/Ternary/Morphisms.agda
@@ -4,7 +4,7 @@ module Relation.Ternary.Morphisms where
 open import Level
 open import Relation.Unary
 open import Relation.Binary.Bundles
-open import Relation.Binary.PropositionalEquality as P
+open import Relation.Binary.PropositionalEquality as P hiding (J)
 open import Data.Product
 open import Function using (_∘_)
 


### PR DESCRIPTION
The `Morphism` module adds a type `J`, however `J` was also recently added to the standard library, so I hid the definition from the standard library to fix the ambiguous name.